### PR TITLE
Avoid RSpec deprecation warnings + fix an issue where a float 0.0 was turned into "0".

### DIFF
--- a/formatting.gemspec
+++ b/formatting.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "attr_extras"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/formatting/number.rb
+++ b/lib/formatting/number.rb
@@ -39,7 +39,7 @@ module Formatting
       end
 
       # Avoid negative zero.
-      number = 0 if number.zero?
+      number = number.abs if number.zero?
 
       if round
         number = number.round(round) if has_decimals

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -18,7 +18,7 @@ describe Formatting do
       end
 
       it "can take a record and a method name" do
-        item.stub(price: 2)
+        allow(item).to receive(:price).and_return(2)
         expect_formatted(item, :price).to eq space_to_nbsp("2.00")
       end
 
@@ -48,12 +48,12 @@ describe Formatting do
       end
 
       it "is read from the record's #currency if present" do
-        item.stub(currency: "SEK")
+        allow(item).to receive(:currency).and_return("SEK")
         expect_formatted(item, 1).to eq space_to_nbsp("1.00 SEK")
       end
 
       it "is not added if the record's #currency is blank" do
-        item.stub(currency: "")
+        allow(item).to receive(:currency).and_return("")
         expect_formatted(item, 1).to eq space_to_nbsp("1.00")
       end
 

--- a/spec/percent_spec.rb
+++ b/spec/percent_spec.rb
@@ -26,7 +26,7 @@ describe Formatting, ".format_percent" do
       let(:i18n) { stub_const("I18n", double) }
 
       it "defaults sensibly for some locales that require spacing the sign" do
-        i18n.stub(locale: :sv)
+        allow(i18n).to receive(:locale).and_return(:sv)
         expect_formatted(1).to eq space_to_nbsp("1.00 %")
       end
     end


### PR DESCRIPTION
This PR

- allows Bundler 2
- uses expect/allow syntax in specs
- fixes a type defect about floats. `0.0` would be turned into an Integer to become absolute. This change makes the number absolute using `#abs`.